### PR TITLE
Add .pubignore file

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,2 @@
+icons/
+build-icons.sh


### PR DESCRIPTION
Exclude all source svg icons and also the build script. That slim down by 1.4 mo the pub package.