### PR TITLE
Animated icons paths overlap when using transparent color

### DIFF
--- a/lib/src/animations/yaru_animated_no_network_icon.dart
+++ b/lib/src/animations/yaru_animated_no_network_icon.dart
@@ -235,14 +235,16 @@ class _YaruAnimatedNoNetworkIconPainter extends CustomPainter {
   Paint _getFillPaint() {
     return Paint()
       ..style = PaintingStyle.fill
-      ..color = color;
+      ..color = color
+      ..blendMode = BlendMode.src;
   }
 
   Paint _getStrokePaint() {
     return Paint()
       ..style = PaintingStyle.stroke
       ..color = color
-      ..strokeWidth = 1 / (_kTargetCanvasSize / size);
+      ..strokeWidth = 1 / (_kTargetCanvasSize / size)
+      ..blendMode = BlendMode.src;
   }
 
   double _computeLocalAnimationPosition(double start, double duration) {

--- a/lib/src/animations/yaru_animated_ok_icon.dart
+++ b/lib/src/animations/yaru_animated_ok_icon.dart
@@ -219,14 +219,16 @@ class _YaruAnimatedOkIconPainter extends CustomPainter {
   Paint _createFillPaint() {
     return Paint()
       ..color = color
-      ..style = PaintingStyle.fill;
+      ..style = PaintingStyle.fill
+      ..blendMode = BlendMode.src;
   }
 
   Paint _createStrokePaint() {
     return Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1 / (_kTargetCanvasSize / size);
+      ..strokeWidth = 1 / (_kTargetCanvasSize / size)
+      ..blendMode = BlendMode.src;
   }
 
   @override


### PR DESCRIPTION
@Feichtmeier I found a super simple and clean solution 🥳🥳🥳

**Before:**

![Capture d’écran du 2022-10-01 13-14-04](https://user-images.githubusercontent.com/36476595/193406894-2fbd3459-6856-4139-927b-061372dfa3c1.png)

**After:**

![Capture d’écran du 2022-10-01 13-13-30](https://user-images.githubusercontent.com/36476595/193406891-14f004db-6d80-4901-9f7f-a09797871a84.png)

Fixes #62