### PR TITLE
Fix example icon table loop indexing

### DIFF
--- a/example/lib/src/icon_table.dart
+++ b/example/lib/src/icon_table.dart
@@ -26,7 +26,7 @@ class YaruIconTable extends StatelessWidget {
           ],
           dataRowHeight: iconSizeProvider.size + 16,
           rows: [
-            for (var i = 0; i < _iconNames.length; i += 2)
+            for (var i = 0; i < _iconNames.length; i += 1)
               DataRow(
                 cells: [
                   DataCell(


### PR DESCRIPTION
@jpnurmi I think you did a little typo in  #71 :)
Only half the icons was showed, because index was incremented by 2.