### PR TITLE
Remove repaint boundary from example app

### DIFF
--- a/example/lib/src/icon_items.dart
+++ b/example/lib/src/icon_items.dart
@@ -10,11 +10,9 @@ final List<IconItem> iconItems = [
     IconItem(
       name: iconName,
       usage: 'YaruIcons.$iconName',
-      iconBuilder: (context, iconSize) => RepaintBoundary(
-        child: Icon(
-          YaruIcons.all[iconName]!,
-          size: iconSize,
-        ),
+      iconBuilder: (context, iconSize) => Icon(
+        YaruIcons.all[iconName]!,
+        size: iconSize,
       ),
     )
 ];


### PR DESCRIPTION
Remove all repaint boundary from example app.
I had put one around each icon in the grid 😅

Also, I didn't put any one around animated icons.