### PR TITLE
Add RepaintBoundary around animated icons

### DIFF
--- a/lib/src/animated_icons/yaru_animated_no_network_icon.dart
+++ b/lib/src/animated_icons/yaru_animated_no_network_icon.dart
@@ -75,11 +75,13 @@ class _YaruAnimatedNoNetworkIconState extends State<YaruAnimatedNoNetworkIcon>
         child: AnimatedBuilder(
           animation: progress,
           builder: (context, child) {
-            return CustomPaint(
-              painter: _YaruAnimatedNoNetworkIconPainter(
-                widget.size,
-                widget.color ?? Theme.of(context).colorScheme.onSurface,
-                progress.value,
+            return RepaintBoundary(
+              child: CustomPaint(
+                painter: _YaruAnimatedNoNetworkIconPainter(
+                  widget.size,
+                  widget.color ?? Theme.of(context).colorScheme.onSurface,
+                  progress.value,
+                ),
               ),
             );
           },

--- a/lib/src/animated_icons/yaru_animated_ok_icon.dart
+++ b/lib/src/animated_icons/yaru_animated_ok_icon.dart
@@ -80,12 +80,14 @@ class _YaruAnimatedOkIconState extends State<YaruAnimatedOkIcon>
         child: AnimatedBuilder(
           animation: progress,
           builder: (context, child) {
-            return CustomPaint(
-              painter: _YaruAnimatedOkIconPainter(
-                widget.size,
-                widget.filled,
-                widget.color ?? Theme.of(context).colorScheme.onSurface,
-                progress.value,
+            return RepaintBoundary(
+              child: CustomPaint(
+                painter: _YaruAnimatedOkIconPainter(
+                  widget.size,
+                  widget.filled,
+                  widget.color ?? Theme.of(context).colorScheme.onSurface,
+                  progress.value,
+                ),
               ),
             );
           },


### PR DESCRIPTION
Add RepaintBoundary around animated icons, to avoid blurry rendering with subpixel alignment.