### PR TITLE
Move RepaintBoundary before ClipRect

### DIFF
--- a/lib/src/animated_icons/yaru_animated_no_network_icon.dart
+++ b/lib/src/animated_icons/yaru_animated_no_network_icon.dart
@@ -69,22 +69,22 @@ class _YaruAnimatedNoNetworkIconState extends State<YaruAnimatedNoNetworkIcon>
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      child: SizedBox.square(
-        dimension: widget.size,
-        child: AnimatedBuilder(
-          animation: progress,
-          builder: (context, child) {
-            return RepaintBoundary(
-              child: CustomPaint(
+    return RepaintBoundary(
+      child: ClipRect(
+        child: SizedBox.square(
+          dimension: widget.size,
+          child: AnimatedBuilder(
+            animation: progress,
+            builder: (context, child) {
+              return CustomPaint(
                 painter: _YaruAnimatedNoNetworkIconPainter(
                   widget.size,
                   widget.color ?? Theme.of(context).colorScheme.onSurface,
                   progress.value,
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/src/animated_icons/yaru_animated_ok_icon.dart
+++ b/lib/src/animated_icons/yaru_animated_ok_icon.dart
@@ -74,23 +74,23 @@ class _YaruAnimatedOkIconState extends State<YaruAnimatedOkIcon>
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      child: SizedBox.square(
-        dimension: widget.size,
-        child: AnimatedBuilder(
-          animation: progress,
-          builder: (context, child) {
-            return RepaintBoundary(
-              child: CustomPaint(
+    return RepaintBoundary(
+      child: ClipRect(
+        child: SizedBox.square(
+          dimension: widget.size,
+          child: AnimatedBuilder(
+            animation: progress,
+            builder: (context, child) {
+              return CustomPaint(
                 painter: _YaruAnimatedOkIconPainter(
                   widget.size,
                   widget.filled,
                   widget.color ?? Theme.of(context).colorScheme.onSurface,
                   progress.value,
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Move `RepaintBoundary` before `ClipRect`, to avoid subpixel crop. When the `RepaintBoundary` is child of `ClipRect`, clip is done at subpixel, while the boundary realigned the canvas on integer coordinates, which will crop a part of the canvas draw.
With this change, the clip is done on integer coordinates.

I also replaced `ClipRRect` (clip with radius) with simple `ClipRect` (clip on widget rect box), because we wasn't use any border radius. The clip widget is only here to avoid any draw outside of the canvas.