### PR TITLE
fix: run the animation again on data change

### DIFF
--- a/lib/src/widgets/animated_icons/yaru_animated_icon.dart
+++ b/lib/src/widgets/animated_icons/yaru_animated_icon.dart
@@ -53,33 +53,27 @@ class _YaruAnimatedIconState extends State<YaruAnimatedIcon>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
-  void _initAnimationController(Duration? duration, YaruAnimationMode mode) {
-    _controller = AnimationController(
-      vsync: this,
-      duration: duration ?? widget.data.defaultDuration,
-    );
-
-    switch (mode) {
-      case YaruAnimationMode.once:
-        _controller.forward();
-        break;
-      case YaruAnimationMode.repeat:
-        _controller.repeat();
-        break;
-    }
-  }
-
   @override
   void initState() {
     super.initState();
-    _initAnimationController(widget.duration, widget.mode);
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration ?? widget.data.defaultDuration,
+    );
+    _runAnimationController();
   }
 
   @override
   void didUpdateWidget(YaruAnimatedIcon old) {
-    if (widget.mode != old.mode || widget.duration != old.duration) {
-      _controller.dispose();
-      _initAnimationController(widget.duration, widget.mode);
+    if (widget.data != old.data) {
+      _controller.value = 0.0;
+    }
+    if (widget.duration != old.duration) {
+      _controller.duration = widget.duration ?? widget.data.defaultDuration;
+    }
+    if (widget.mode != old.mode || widget.data != old.data) {
+      _runAnimationController();
     }
 
     super.didUpdateWidget(old);
@@ -89,6 +83,17 @@ class _YaruAnimatedIconState extends State<YaruAnimatedIcon>
   void dispose() {
     _controller.dispose();
     super.dispose();
+  }
+
+  void _runAnimationController() {
+    switch (widget.mode) {
+      case YaruAnimationMode.once:
+        _controller.forward();
+        break;
+      case YaruAnimationMode.repeat:
+        _controller.repeat();
+        break;
+    }
   }
 
   @override


### PR DESCRIPTION
- run the animation again on animation data change (Ex: fill the icon on button click) ;
- fix `_YaruAnimatedIconState is a SingleTickerProviderStateMixin but multiple tickers were created.` error when change the animation mode or duration.

**Before:**

[Capture vidéo du 2023-07-30 11-23-29.webm](https://github.com/ubuntu/yaru_icons.dart/assets/36476595/159545c6-2864-400e-b02c-124a2bddc17f)

**After:**

[Capture vidéo du 2023-07-30 11-22-51.webm](https://github.com/ubuntu/yaru_icons.dart/assets/36476595/d9ce11e9-c371-4c6a-af5a-130b81c0c93b)
