### PR TITLE
fix: YaruAnimatedOkIcon diff paint glitch

### DIFF
--- a/lib/src/widgets/animated_icons/yaru_animated_ok_icon.dart
+++ b/lib/src/widgets/animated_icons/yaru_animated_ok_icon.dart
@@ -114,8 +114,12 @@ class _YaruAnimatedOkIconPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    canvas.saveLayer(null, Paint());
+
     _paintOuterCirclePath(canvas);
     _paintCheckmark(canvas);
+
+    canvas.restore();
   }
 
   void _paintOuterCirclePath(Canvas canvas) {


### PR DESCRIPTION
When the dialog pop out, the checkmark diff paint is glitching.

**Before:**

![image](https://github.com/ubuntu/yaru_icons.dart/assets/36476595/da842a2f-10b6-4d58-b9a8-f1d849a6717a)

_I can't catch this problem in a video capture_

**After:**

[Capture vidéo du 2023-08-15 12-46-04.webm](https://github.com/ubuntu/yaru_icons.dart/assets/36476595/b8c2fd1f-fca0-4481-bcbc-8428f28617bc)
