### PR TITLE
fix: ClipRRect borderRadius non-nullable

### DIFF
--- a/lib/src/widgets/yaru_placeholder_icon.dart
+++ b/lib/src/widgets/yaru_placeholder_icon.dart
@@ -50,7 +50,7 @@ class YaruPlaceholderIcon extends StatelessWidget {
     }
 
     return ClipRRect(
-      borderRadius: borderRadius,
+      borderRadius: borderRadius ?? BorderRadius.zero,
       child: child,
     );
   }


### PR DESCRIPTION
Fix compatibility with Flutter 3.13
Related to https://github.com/flutter/flutter/pull/125878