### PR TITLE
chore: better dependabot.yaml commit message prefix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,4 +5,5 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
I just checked `yaru_widgets` repo, and it was done differently: https://github.com/ubuntu/yaru_widgets.dart/blob/main/.github/dependabot.yaml