### PR TITLE
fix: enable icon tree-shaking

### DIFF
--- a/example/lib/src/icon_items.dart
+++ b/example/lib/src/icon_items.dart
@@ -22,7 +22,7 @@ final List<IconItem> _staticIconItems = [
         YaruIcons.all[iconName]!,
         size: iconSize,
       ),
-    )
+    ),
 ];
 
 final List<IconItem> _animatedIconItems = [

--- a/lib/src/yaru_icons.dart
+++ b/lib/src/yaru_icons.dart
@@ -23,6 +23,7 @@ import 'package:flutter/widgets.dart';
 ///       fonts:
 ///         - asset: fonts/yaru_icons.otf
 /// ```
+@staticIconProvider
 class YaruIcons {
   const YaruIcons._();
 


### PR DESCRIPTION
I just noticed that material `Icons` class was using this `@staticIconProvider` annotation to enable icon tree-shaking.
This is quite important because it reduce the size of asset font during release builds by removing unused icons.